### PR TITLE
Fix removed tag analytics

### DIFF
--- a/pages/blog-single/[id].js
+++ b/pages/blog-single/[id].js
@@ -11,6 +11,25 @@ const BlogSingle = () => {
   const router = useRouter();
   const {id} = router.query;
 
+  // Log click events for analytics
+  const recordClick = async (clickEvent, targetUrl) => {
+    const localTime = new Date().toISOString();
+    const pageUrl   = targetUrl || window.location.href;
+    try {
+      await fetch('/api/click', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clickEvent, targetUrl: pageUrl, localTime })
+      });
+    } catch (err) {
+      console.error("Error logging click event:", err);
+    }
+  };
+
+  useEffect(() => {
+    recordClick('page-load');
+  }, []);
+
   useEffect(() => {
     if (!id) return; // Avoid fetching if the id isn't available yet
 
@@ -51,7 +70,11 @@ const BlogSingle = () => {
               <div className="m-titles">
                 <h1 className="m-title">{blog.title}</h1>
                 <div className="m-category">
-                  <a href="#" rel="category tag">
+                  <a
+                    href="#"
+                    rel="category tag"
+                    
+                  >
                     {blog.category}
                   </a>{" "}
                   / {blog.date}
@@ -81,7 +104,10 @@ const BlogSingle = () => {
                     {blog.tags.split(',').map((tag, index) => (
                       // Assuming you want to simply display the tags without linking to a specific URL
                       // If you have a tagging system where each tag has a specific URL, adjust the href accordingly
-                      <a href="#" key={index}>
+                      <a
+                        href="#"
+                        key={index}
+                      >
                         {tag.trim()} {/* Trim to remove any potential whitespace */}
                         {index < blog.tags.split(',').length - 1 ? '' : ''}
                       </a>

--- a/pages/index.js
+++ b/pages/index.js
@@ -507,7 +507,6 @@ const Index = () => {
                         <Link href={`/blog-single/${blog.id}`} legacyBehavior>
                           <a
                             className="lnk"
-                            onClick={() => recordClick("blog-readmore", `/blog-single/${blog.id}`)}
                           >
                             Read more
                           </a>
@@ -569,7 +568,7 @@ const Index = () => {
                 <div key={id} className="archive-item">
                   <div className="image">
                     <Link href={href} legacyBehavior>
-                      <a onClick={() => recordClick("life-blog-item", href)}>
+                      <a >
                         <img src={image_url} alt={title}/>
                       </a>
                     </Link>
@@ -584,7 +583,7 @@ const Index = () => {
 
                     <h3 className="title">
                       <Link href={href} legacyBehavior>
-                        <a onClick={() => recordClick("life-blog", href)}>
+                        <a >
                           {title}
                           {require_login && " (login required)"}
                         </a>
@@ -598,7 +597,7 @@ const Index = () => {
                         <Link href={href} legacyBehavior>
                           <a
                             className="lnk"
-                            onClick={() => recordClick("life-blog", href)}
+                            
                           >
                             {require_login ? "Log in to read" : "Read more"}
                           </a>

--- a/pages/life-blog/[id].js
+++ b/pages/life-blog/[id].js
@@ -12,6 +12,25 @@ const LifeBlog = () => {
   const {id} = router.query;
   const [loggedIn,  setLoggedIn]  = useState(false);
 
+  // Log click events for analytics
+  const recordClick = async (clickEvent, targetUrl) => {
+    const localTime = new Date().toISOString();
+    const pageUrl   = targetUrl || window.location.href;
+    try {
+      await fetch('/api/click', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clickEvent, targetUrl: pageUrl, localTime })
+      });
+    } catch (err) {
+      console.error("Error logging click event:", err);
+    }
+  };
+
+  useEffect(() => {
+    recordClick('page-load');
+  }, []);
+
   /* ────────── 1. one‑off session check ────────── */
   useEffect(() => {
     (async () => {
@@ -73,7 +92,11 @@ const LifeBlog = () => {
               <div className="m-titles">
                 <h1 className="m-title">{blog.title}</h1>
                 <div className="m-category">
-                  <a href="#" rel="category tag">
+                  <a
+                    href="#"
+                    rel="category tag"
+                    
+                  >
                     {blog.category}
                   </a>{" "}
                   / {blog.date}
@@ -103,7 +126,10 @@ const LifeBlog = () => {
                     {blog.tags.split(',').map((tag, index) => (
                       // Assuming you want to simply display the tags without linking to a specific URL
                       // If you have a tagging system where each tag has a specific URL, adjust the href accordingly
-                      <a href="#" key={index}>
+                      <a
+                        href="#"
+                        key={index}
+                      >
                         {tag.trim()} {/* Trim to remove any potential whitespace */}
                         {index < blog.tags.split(',').length - 1 ? '' : ''}
                       </a>

--- a/pages/work-single/[id].js
+++ b/pages/work-single/[id].js
@@ -11,6 +11,25 @@ const WorkSingle = () => {
   const router = useRouter();
   const { id } = router.query;
 
+  // Helper to log click events for analytics
+  const recordClick = async (clickEvent, targetUrl) => {
+    const localTime = new Date().toISOString();
+    const pageUrl   = targetUrl || window.location.href;
+    try {
+      await fetch('/api/click', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clickEvent, targetUrl: pageUrl, localTime })
+      });
+    } catch (err) {
+      console.error("Error logging click event:", err);
+    }
+  };
+
+  useEffect(() => {
+    recordClick('page-load');
+  }, []);
+
   useEffect(() => {
     const fetchProject = async () => {
       if (!id) return; // Don't proceed if ID is not yet available
@@ -95,7 +114,13 @@ const WorkSingle = () => {
                   <span>Link</span>
                   <strong>
                     <Link href={project.URL}>
-                      <a target="_blank" rel="noopener noreferrer">Source Code</a>
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        
+                      >
+                        Source Code
+                      </a>
                     </Link>
                   </strong>
                 </div>


### PR DESCRIPTION
## Summary
- stop tracking clicks from home page
- keep page visit logging on blog, life blog, and project detail pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3f923ee883258a5668b0c6c0d770