### PR TITLE
Improve life blog layout and sorting

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -66,7 +66,7 @@ const Index = () => {
       const { data: life, error: lifeErr } = await supabase
         .from("life_blogs")
         .select("id, title, image_url, category, published_at, description, require_login")
-        .order("published_at", { ascending: false });
+        .order("created_at", { ascending: true });
       if (lifeErr) return setError(lifeErr.message);
       setLifeBlogs(life);
 
@@ -548,7 +548,7 @@ const Index = () => {
             </div>
           </div>
 
-          <div className="blog-items grid gap-8 lg:grid-cols-3">
+          <div className="blog-items grid gap-16 lg:grid-cols-3">
             {lifeBlogs.slice(0, 3).map(blog => {
               const {
                 id,


### PR DESCRIPTION
## Summary
- sort life blogs by `created_at` ascending so older posts show first
- increase whitespace between life blog entries on the home page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba966863c8325b517a502443cb9a5