### PR TITLE
Remove LinkedIn links and update project filtering

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -200,14 +200,6 @@ const Index = () => {
                   <a
                     target="_blank"
                     rel="noreferrer"
-                    href="https://www.linkedin.com/in/yuqi-g-185957355/"
-                    onClick={() => recordClick("social-link", "https://www.linkedin.com/in/yuqi-g-185957355/")}
-                  >
-                    <i aria-hidden="true" className="fab fa-linkedin"/>
-                  </a>
-                  <a
-                    target="_blank"
-                    rel="noreferrer"
                     href="https://github.com/YuqiGuo105"
                     onClick={() => recordClick("social-link", "https://github.com/YuqiGuo105")}
                   >

--- a/src/components/ProjectIsotop.js
+++ b/src/components/ProjectIsotop.js
@@ -14,7 +14,7 @@ const ProjectIsotop = () => {
       const {data, error} = await supabase
         .from('Projects')
         .select('*')
-        .order('num', {ascending: true});
+        .order('num', {ascending: false});
 
       if (!error) {
         setProjects(data);
@@ -62,19 +62,6 @@ const ProjectIsotop = () => {
   // Determine active button class
   const activeBtn = (value) => (value === filterKey ? "active" : "");
 
-  // Helper to record click events (you can also move this into a shared utils file)
-  const recordClick = async (clickEvent, targetUrl) => {
-    const localTime = new Date().toISOString();
-    try {
-      await fetch('/api/click', {      // or '/click' if that's your setup
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ clickEvent, targetUrl, localTime }),
-      });
-    } catch (err) {
-      console.error('Error logging click event:', err);
-    }
-  };
 
   return (
     <Fragment>
@@ -91,14 +78,20 @@ const ProjectIsotop = () => {
         <div className="works-items works-list-items row">
           {projects.map((project) => {
             const targetUrl = `/work-single/${project.id}`;
+            const categoryClasses = project.category
+              ? project.category
+                  .split(',')
+                  .map((cat) => cat.trim().replace(/\s+/g, '-'))
+                  .join(' ')
+              : '';
             return (
               <div
                 key={project.id}
-                className={`works-col col-xs-12 col-sm-12 col-md-12 col-lg-12 ${project.category}`}
+                className={`works-col col-xs-12 col-sm-12 col-md-12 col-lg-12 ${categoryClasses}`}
               >
                 <div className="works-item">
                   <Link href={targetUrl} passHref>
-                    <a onClick={() => recordClick('project-item', targetUrl)}>
+                    <a>
                       <span className="image">
                         <span className="img">
                           <img src={project.image_url} alt={project.title}/>

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -9,9 +9,6 @@ const Footer = () => {
               <div
                 className="social-links"
               >
-                <a target="_blank" rel="noreferrer" href="https://www.linkedin.com/in/yuqi-g-185957355/">
-                  <i aria-hidden="true" className="fab fa-linkedin"/>
-                </a>
                 <a target="_blank" rel="noreferrer" href="https://github.com/YuqiGuo105">
                   <i aria-hidden="true" className="fab fa-github"/>
                 </a>

--- a/src/layout/Header.js
+++ b/src/layout/Header.js
@@ -283,13 +283,6 @@ const Header = () => {
         {/* social */}
         <div className="menu-social-links">
           <a
-              href="https://www.linkedin.com/in/yuqi-g-ab3380146"
-              target="blank"
-            title="dribbble"
-          >
-            <i className="fab fa-linkedin" />
-          </a>
-          <a
             href="https://github.com/YuqiGuo105"
             target="blank"
             title="twitter"


### PR DESCRIPTION
## Summary
- remove LinkedIn links/icons from layout and index page
- order projects by `num` descending
- support comma separated categories in `ProjectIsotop`
- remove click tracking from project items

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550c0800848325b79fb32a1418d1e9