### PR TITLE
Fix chat widget icon alignment

### DIFF
--- a/src/components/ChatWidget.js
+++ b/src/components/ChatWidget.js
@@ -279,14 +279,17 @@ function LauncherButton({ onOpen }) {
       onClick={onOpen}
       className="relative flex items-center rounded-full mb-2 px-5 py-4 shadow-xl ring-1 ring-gray-200 backdrop-blur transition hover:shadow-2xl supports-[backdrop-filter]:bg-white/75 dark:bg-gray-900 dark:ring-gray-700 launch-button"
     >
-      <span className="relative flex h-15 w-15 items-center justify-center rounded-full bg-blue-600">
+      <span
+        className="relative flex items-center justify-center rounded-full bg-blue-600"
+        style={{ width: 60, height: 60 }}
+      >
         <Image
           src="/assets/images/chatPot.png"
           alt="Chat Bot"
           width={48}
           height={48}
           priority
-          className={`w-12 h-12 object-contain pot-image ${animating ? 'shake' : ''}`}
+          className={`object-contain pot-image ${animating ? 'shake' : ''}`}
         />
         <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-green-500 ring-2 ring-white dark:ring-gray-900"/>
       </span>

--- a/styles/chatWidget.css
+++ b/styles/chatWidget.css
@@ -38,6 +38,7 @@
       height: 48px;
       width: 48px;
       margin-bottom: 0;
+      display: block;
     }
   }
   .launch-button:hover {


### PR DESCRIPTION
## Summary
- adjust launcher button container dimensions
- display chat icon as a block element to center it

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685794b6257c83258f2dc454b42f6a71