### PR TITLE
Improve custom cursor responsiveness

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -32,11 +32,12 @@ export function initCursor() {
     });
   });
 
-  setInterval(move, 1000 / 60);
-  function move() {
-    cursor.x = lerp(cursor.x, mouseX, 0.1);
-    cursor.y = lerp(cursor.y, mouseY, 0.1);
+  requestAnimationFrame(animate);
+  function animate() {
+    cursor.x = lerp(cursor.x, mouseX, 0.2);
+    cursor.y = lerp(cursor.y, mouseY, 0.2);
     cursor.update();
+    requestAnimationFrame(animate);
   }
   function lerp(start, end, amt) {
     return (1 - amt) * start + amt * end;


### PR DESCRIPTION
## Summary
- use `requestAnimationFrame` for smoother cursor updates
- increase interpolation factor for quicker response

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858493133d88325a0e6a8400b7cc5ad