### PR TITLE
Improve basic SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ To get a local copy up and running follow these simple steps.
 - Browse the project portfolio and use the contact form to send messages directly to the project owner's email.
 - Utilize Supabase as database, so user can edit work/blog part.
 - Integrate WYSIWYG to web content that user can easily editor "Blogs"/"Work" content.
+
+## SEO Improvements
+This project includes basic search engine optimization features:
+- Meta tags for titles and descriptions using a reusable `SeoHead` component.
+- `robots.txt` and `sitemap.xml` are provided in the `public` folder for better crawling.
 ## Contributing
 Contributions are what make the open-source community such an amazing place to learn, inspire, and create. Any contributions you make are greatly appreciated.
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import Head from "next/head";
 import { Fragment } from "react";
+import SeoHead from "../src/components/SeoHead";
 import "../styles/globals.css";
 import '../styles/carousel.css'
 import '../styles/chatWidget.css'
@@ -70,6 +71,7 @@ function MyApp({ Component, pageProps }) {
         <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
         <link rel="icon" href="/favicon.ico" type="image/x-icon" />
       </Head>
+      <SeoHead />
       <Component {...pageProps} />{" "}
     </Fragment>
   );

--- a/pages/blog-single/[id].js
+++ b/pages/blog-single/[id].js
@@ -2,6 +2,7 @@ import Layout from "../../src/layout/Layout";
 import {supabase} from '../../src/supabase/supabaseClient';
 import {useRouter} from 'next/router';
 import {useState, useEffect} from 'react';
+import SeoHead from "../../src/components/SeoHead";
 import DOMPurify from 'dompurify';
 
 const BlogSingle = () => {
@@ -60,7 +61,9 @@ const BlogSingle = () => {
   if (!blog) return <div>Blog post not found.</div>;
 
   return (
-    <Layout extraWrapClass={"single-post"}>
+    <>
+      <SeoHead title={blog.title} description={blog.description} />
+      <Layout extraWrapClass={"single-post"}>
       {/* Section Started Heading */}
       <section className="section section-inner started-heading">
         <div className="container">
@@ -122,6 +125,7 @@ const BlogSingle = () => {
         </div>
       </section>
     </Layout>
+    </>
   );
 };
 export default BlogSingle;

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import Link from "next/link";
 import ContactForm from "../src/components/ContactForm";
 import TestimonialSlider from "../src/components/TestimonialSlider";
 import Layout from "../src/layout/Layout";
+import SeoHead from "../src/components/SeoHead";
 import {useEffect, useState} from "react";
 import {supabase} from "../src/supabase/supabaseClient";
 import Slider from "react-slick";
@@ -146,7 +147,9 @@ const Index = () => {
   };
 
   return (
-    <Layout>
+    <>
+      <SeoHead title="Yuqi Guo Portfolio" />
+      <Layout>
       <section className="section section-started">
         <div className="container">
           {/* Hero Started */}
@@ -625,6 +628,7 @@ const Index = () => {
 
       <ContactForm/>
     </Layout>
+    </>
   );
 };
 export default Index;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.yuqi.site/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.yuqi.site/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.yuqi.site/blog</loc>
+  </url>
+  <url>
+    <loc>https://www.yuqi.site/works</loc>
+  </url>
+</urlset>

--- a/src/components/SeoHead.js
+++ b/src/components/SeoHead.js
@@ -1,0 +1,36 @@
+import Head from 'next/head'
+
+const SeoHead = ({
+  title,
+  description = "Portfolio and blog of Yuqi Guo featuring project showcases and tech articles.",
+  keywords = "Yuqi Guo, portfolio, blog, projects, software engineer",
+  image = "/assets/images/profile_guyuqi.jpg",
+  url = "https://www.yuqi.site"
+}) => {
+  const siteTitle = "Yuqi Guo's Blog";
+  const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
+  const metaUrl = url;
+
+  return (
+    <Head>
+      <title>{metaTitle}</title>
+      <meta name="description" content={description} />
+      <meta name="keywords" content={keywords} />
+      <link rel="canonical" href={metaUrl} />
+      {/* Open Graph / Facebook */}
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={metaUrl} />
+      <meta property="og:title" content={metaTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={image} />
+      {/* Twitter */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta property="twitter:url" content={metaUrl} />
+      <meta name="twitter:title" content={metaTitle} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+    </Head>
+  )
+}
+
+export default SeoHead


### PR DESCRIPTION
## Summary
- add SeoHead component with meta tags
- include SeoHead on key pages
- provide robots.txt and sitemap.xml
- document SEO setup in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e36fb06c832590a5728405da0ec8