### PR TITLE
Add login modal and update blog auth

### DIFF
--- a/pages/life-blog/[id].js
+++ b/pages/life-blog/[id].js
@@ -62,7 +62,7 @@ const LifeBlog = () => {
 
       /* gate: requires login? */
       if (data.require_login && !loggedIn) {
-        router.replace(`/login?next=/life-blog/${id}`);
+        router.replace('/');
         return;
       }
 

--- a/src/components/LoginModal.js
+++ b/src/components/LoginModal.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { supabase } from '../supabase/supabaseClient';
 
@@ -7,6 +7,19 @@ const LoginModal = ({ open, onClose, nextUrl = '/' }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
+
+  const handleClose = () => {
+    setError(null);
+    onClose();
+  };
+
+  useEffect(() => {
+    const esc = (e) => {
+      if (e.key === 'Escape') handleClose();
+    };
+    document.addEventListener('keydown', esc);
+    return () => document.removeEventListener('keydown', esc);
+  }, []);
 
   if (!open) return null;
 
@@ -19,15 +32,15 @@ const LoginModal = ({ open, onClose, nextUrl = '/' }) => {
       setEmail('');
       setPassword('');
       setError(null);
-      onClose();
+      handleClose();
       router.push(nextUrl);
     }
   };
 
   return (
-    <div className="modal-backdrop">
-      <div className="modal">
-        <button className="close" onClick={onClose}>×</button>
+    <div className="modal-backdrop" onClick={handleClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <button className="close" onClick={handleClose}>×</button>
         <h2>Login</h2>
         {error && <p className="error">{error}</p>}
         <form onSubmit={handleSubmit}>

--- a/src/components/LoginModal.js
+++ b/src/components/LoginModal.js
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { supabase } from '../supabase/supabaseClient';
+
+const LoginModal = ({ open, onClose, nextUrl = '/' }) => {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  if (!open) return null;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setError(error.message);
+    } else {
+      setEmail('');
+      setPassword('');
+      setError(null);
+      onClose();
+      router.push(nextUrl);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop">
+      <div className="modal">
+        <button className="close" onClick={onClose}>×</button>
+        <h2>Login</h2>
+        {error && <p className="error">{error}</p>}
+        <form onSubmit={handleSubmit}>
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <button type="submit">Sign in</button>
+        </form>
+      </div>
+      <style jsx>{`
+        .modal-backdrop {
+          position: fixed;
+          top: 0; left: 0; right: 0; bottom: 0;
+          background: rgba(0,0,0,0.5);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          z-index: 1000;
+        }
+        .modal {
+          background: #fff;
+          padding: 1.5rem;
+          border-radius: 8px;
+          position: relative;
+          max-width: 400px;
+          width: 100%;
+        }
+        .close {
+          position: absolute;
+          top: 0.5rem;
+          right: 0.5rem;
+          border: none;
+          background: none;
+          font-size: 1.5rem;
+          cursor: pointer;
+        }
+        .error {
+          color: red;
+          margin-bottom: 0.5rem;
+        }
+        form input {
+          display: block;
+          width: 100%;
+          margin-bottom: 0.5rem;
+          padding: 0.5rem;
+        }
+        form button {
+          width: 100%;
+          padding: 0.5rem;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default LoginModal;


### PR DESCRIPTION
## Summary
- add a `LoginModal` component with Supabase email/password sign-in
- check authentication status in home page
- open login dialog when protected LifeBlog items are clicked
- redirect unauthenticated access of LifeBlog posts to home page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686702311ed48325b2bf56b153aebe7c