### PR TITLE
Fix profile story error handling

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -150,6 +150,8 @@ const Index = () => {
         setStories(formatted);
       } catch (err) {
         console.error("❌ Failed to fetch stories:", err);
+        setStories([]);
+        setIsPlaying(false);
       }
     };
 


### PR DESCRIPTION
## Summary
- disable profile story animation if fetching stories fails

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c835d6ef883259e071053bebcebc2