### PR TITLE
CC sender in contact form emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ To get a local copy up and running follow these simple steps.
   EMAIL_USER=USER_EMAIL
   EMAIL_PASS=YOUR_PASS
   EMAIL_TO=TO_USER
+  NEXT_PUBLIC_STORIES_OWNER=OWNER_EMAIL
   ```
 
 - Running the project

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -12,9 +12,9 @@ export default async function handler(req, res) {
 
   const user = process.env.EMAIL_USER;
   const pass = process.env.EMAIL_PASS;
-  const toAddress = process.env.EMAIL_TO;
+  const ownerAddress = process.env.NEXT_PUBLIC_STORIES_OWNER || process.env.EMAIL_TO;
 
-  if (!user || !pass || !toAddress) {
+  if (!user || !pass || !ownerAddress) {
     return res.status(500).json({ error: 'Server configuration error' });
   }
 
@@ -28,7 +28,8 @@ export default async function handler(req, res) {
 
   const mailOptions = {
     from: `"Website Contact Form" <${user}>`,
-    to: toAddress,
+    to: ownerAddress,
+    cc: email,
     replyTo: email,
     subject: `New message from ${name}`,
     text: `Message from ${name} (${email}):\n\n${message}`,


### PR DESCRIPTION
## Summary
- ensure serverless email sends to `NEXT_PUBLIC_STORIES_OWNER`
- cc the email provided in the contact form
- document new env var in the README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686caa3211c4832589cc6b219cce9ab6