### PR TITLE
Add CC to contact form email

### DIFF
--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -29,6 +29,7 @@ export default async function handler(req, res) {
   const mailOptions = {
     from: `"Website Contact Form" <${user}>`,
     to: toAddress,
+    cc: email,
     replyTo: email,
     subject: `New message from ${name}`,
     text: `Message from ${name} (${email}):\n\n${message}`,


### PR DESCRIPTION
## Summary
- cc the sender's email address when sending contact form emails

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cac058d248325b3214c00b881f0c1