### PR TITLE
Handle missing story endpoint env vars

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -126,6 +126,12 @@ const Index = () => {
       try {
         const endpoint = process.env.NEXT_PUBLIC_STORIES_ENDPOINT;
         const owner    = encodeURIComponent(process.env.NEXT_PUBLIC_STORIES_OWNER);
+        if (!endpoint || !process.env.NEXT_PUBLIC_STORIES_OWNER) {
+          console.warn("Stories endpoint/owner env vars missing – skipping stories fetch.");
+          setStories([]);
+          setIsPlaying(false);
+          return;
+        }
         const res      = await fetch(`${endpoint}/records/owner/${owner}`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
 


### PR DESCRIPTION
## Summary
- guard the stories fetch against missing endpoint/owner environment variables
- avoid hitting an undefined endpoint that caused HTTP 500 responses

## Testing
- not run (next lint prompt requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68dfcfe582148325ba3213a594376179