### PR TITLE
Handle missing Supabase config and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,36 @@ To get a local copy up and running follow these simple steps.
   EMAIL_TO=TO_USER
   ```
 
+### Supabase setup
+
+1. **Create a project** at [app.supabase.com](https://app.supabase.com) and copy the "Project URL" and "anon" API key from the _Project Settings → API_ page. Paste them into the `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` variables shown above.
+2. **Create the `visitor_logs` table** (used by `/api/track`) by running the SQL below in the Supabase SQL editor:
+   ```sql
+   create table if not exists public.visitor_logs (
+     id uuid default gen_random_uuid() primary key,
+     created_at timestamptz default now(),
+     local_time timestamptz,
+     event text,
+     ip text,
+     ua text,
+     country text,
+     region text,
+     city text,
+     latitude double precision,
+     longitude double precision
+   );
+   ```
+3. **Enable Row Level Security (RLS)** on the table and add a policy to allow inserts from the anon key:
+   ```sql
+   alter table public.visitor_logs enable row level security;
+
+   create policy "Allow inserts from anon" on public.visitor_logs
+     for insert
+     to anon
+     with check (true);
+   ```
+4. Deploy the updated environment variables to Vercel (or your hosting provider) so the API route can access Supabase in production.
+
 - Running the project
   ```sh
   npm run dev

--- a/pages/api/track.js
+++ b/pages/api/track.js
@@ -44,6 +44,11 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    console.warn('[Track] Supabase credentials missing – skipping insert');
+    return res.status(200).json({ ok: true, skipped: 'supabase-not-configured' });
+  }
+
   const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body || {};
   const { localTime = new Date().toISOString(), event = 'page_view' } = body;
 


### PR DESCRIPTION
## Summary
- prevent the visitor tracking endpoint from failing when Supabase credentials are not provided
- document how to configure Supabase and provision the visitor_logs table

## Testing
- no automated tests were run (not configured)

------
https://chatgpt.com/codex/tasks/task_e_68dfd2b599a883258c48878f88bb0bc9